### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The plugin is available in the `window` object as `window.stunningImageMaps`, so
 
 
 ```
-stunningImageMaps.run();
+stunningImageMaps.toSVG();
 ```
 
 #### jQuery


### PR DESCRIPTION
The method `.run()` was changed under development to `.toSVG()`. The documentation is now updated correctly with the right method name.
